### PR TITLE
Add: Benchmarking with Criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,10 @@ log = "0.4.19"
 nb = "1.1.0"
 pwm-pca9685 = "0.3.1"
 sk6812_rpi = "0.1"
+
+[dev-dependencies]
+criterion = { version = "0.5.1", features = ["html_reports"] }
+
+[[bench]]
+name = "bench"
+harness = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,45 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use navigator_rs::{AdcChannel, Navigator, PwmChannel, UserLed};
+
+fn navigator_benchmark(c: &mut Criterion) {
+    #[macro_export]
+    macro_rules! bench {
+    ($bench_fn:ident($($arg:tt)*)) => {
+        let mut nav = Navigator::new();
+        nav.init();
+        c.bench_function(stringify!($bench_fn), |b| b.iter(|| nav.$bench_fn($($arg)*)));
+    }}
+
+    // Navigator creation benchmark
+    c.bench_function("new", |b| b.iter(|| Navigator::new()));
+
+    // Benchmark Inputs
+    bench!(init());
+
+    bench!(read_adc(AdcChannel::Ch0));
+    bench!(read_adc_all());
+
+    bench!(read_accel());
+    bench!(read_gyro());
+    bench!(read_mag());
+
+    bench!(read_pressure());
+    bench!(read_temperature());
+
+    bench!(read_all());
+
+    // Benchmark Outputs
+    bench!(pwm_enable(false));
+    bench!(set_pwm_channel_value(PwmChannel::Ch1, 100));
+    bench!(set_pwm_freq_hz(60.0));
+    bench!(set_pwm_freq_prescale(100));
+
+    bench!(set_neopixel(&[[0, 0, 0]]));
+
+    bench!(set_led(UserLed::Led1, false));
+    bench!(set_led_toggle(UserLed::Led1));
+    bench!(get_led(UserLed::Led1));
+}
+
+criterion_group!(benches, navigator_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
A fast way to benchmark our functions, seems work pretty fine locally and on hosted-ci-runner.

cargo bench --jobs 1 --bench bench | tee output.txt
```
new                     time:   [190.92 ms 190.98 ms 191.04 ms]
Found 12 outliers among 100 measurements (12.00%)
  8 (8.00%) low severe
  2 (2.00%) high mild
  2 (2.00%) high severe

init                    time:   [328.32 ms 328.46 ms 328.60 ms]
Found 16 outliers among 100 measurements (16.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high mild
  13 (13.00%) high severe

read_adc                time:   [9.9898 ms 10.011 ms 10.030 ms]
Found 19 outliers among 100 measurements (19.00%)
  13 (13.00%) low severe
  4 (4.00%) low mild
  2 (2.00%) high severe

read_adc_all            time:   [39.829 ms 39.941 ms 40.044 ms]
Found 21 outliers among 100 measurements (21.00%)
  19 (19.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high severe

read_accel              time:   [219.62 µs 221.09 µs 222.62 µs]
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

read_gyro               time:   [220.10 µs 221.02 µs 221.97 µs]
Found 13 outliers among 100 measurements (13.00%)
  8 (8.00%) low mild
  1 (1.00%) high mild
  4 (4.00%) high severe

read_mag                time:   [80.236 ms 87.279 ms 94.314 ms]
Found 22 outliers among 100 measurements (22.00%)
  15 (15.00%) low severe
  6 (6.00%) low mild
  1 (1.00%) high mild

read_pressure           time:   [1.3235 ms 1.3275 ms 1.3307 ms]
Found 17 outliers among 100 measurements (17.00%)
  12 (12.00%) low severe
  2 (2.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

read_temperature        time:   [655.14 µs 658.95 µs 662.38 µs]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

read_all                time:   [44.203 ms 44.341 ms 44.467 ms]
Found 16 outliers among 100 measurements (16.00%)
  16 (16.00%) low severe

pwm_enable              time:   [39.916 µs 40.393 µs 40.864 µs]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

set_pwm_channel_value   time:   [124.33 µs 125.26 µs 125.98 µs]

set_pwm_freq_hz         time:   [140.49 µs 142.74 µs 145.37 µs]

set_pwm_freq_prescale   time:   [157.34 µs 160.03 µs 162.46 µs]
Found 17 outliers among 100 measurements (17.00%)
  10 (10.00%) low severe
  5 (5.00%) high mild
  2 (2.00%) high severe

set_neopixel            time:   [259.98 µs 260.94 µs 262.19 µs]
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  8 (8.00%) high severe

set_led                 time:   [39.801 µs 40.025 µs 40.246 µs]
Found 15 outliers among 100 measurements (15.00%)
  8 (8.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe

set_led_toggle          time:   [86.171 µs 86.801 µs 87.462 µs]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

get_led                 time:   [45.210 µs 45.947 µs 46.941 µs]
Found 15 outliers among 100 measurements (15.00%)
  9 (9.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
```